### PR TITLE
Add cart is busy feature

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -7,6 +7,9 @@ module Spree
     include Spree::Order::CurrencyUpdater
     include Spree::Core::Permalinks.new(prefix: 'R')
 
+    # Error raised on concurrent order operations
+    OrderBusyError = Class.new(RuntimeError)
+
     MONEY_THRESHOLD  = 999_999
     MONEY_VALIDATION = {
       presence:     true,


### PR DESCRIPTION
To avoid concurrent operations being queued up on the order locking, especially to avoid the queue overrrunning the request timeouts we want to avoid building up an order related queue.

* [x] Add `NOWAIT` option to logs and provide domain level exception for busy cart
* ¨~~Set a configurable lock wait timeout based on above logic~~ In next iteration.