### PR TITLE
Add missing dependent options to polymorphic associations

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,7 +1,7 @@
 module Spree
   class CreditCard < Spree::Base
     belongs_to :payment_method
-    has_many :payments, as: :source
+    has_many :payments, as: :source, dependent: :restrict_with_exception
 
     before_create :set_missing_info
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -12,8 +12,8 @@ module Spree
 
     has_many :offsets, -> { where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'") },
       class_name: "Spree::Payment", foreign_key: :source_id
-    has_many :log_entries, as: :source
-    has_many :state_changes, as: :stateful
+    has_many :log_entries, as: :source, dependent: :restrict_with_exception
+    has_many :state_changes, as: :stateful, dependent: :restrict_with_exception
     has_many :capture_events, :class_name => 'Spree::PaymentCaptureEvent'
 
     before_validation :validate_source

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -10,7 +10,7 @@ module Spree
 
     has_many :shipping_rates, -> { order('cost ASC') }, dependent: :delete_all
     has_many :shipping_methods, through: :shipping_rates
-    has_many :state_changes, as: :stateful
+    has_many :state_changes, as: :stateful, dependent: :restrict_with_exception
     has_many :inventory_units, dependent: :delete_all, inverse_of: :shipment
 
     after_save :update_adjustments

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -2,7 +2,7 @@ module Spree
   class StockTransfer < Spree::Base
     include Spree::Core::Permalinks.new(prefix: 'T')
 
-    has_many :stock_movements, :as => :originator
+    has_many :stock_movements, :as => :originator, :dependent => :restrict_with_exception
 
     belongs_to :source_location, :class_name => 'StockLocation'
     belongs_to :destination_location, :class_name => 'StockLocation'

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -21,7 +21,7 @@ module Spree
     belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates
     belongs_to :tax_category, class_name: "Spree::TaxCategory", inverse_of: :tax_rates
 
-    has_many :adjustments, as: :source
+    has_many :adjustments, as: :source, dependent: :restrict_with_exception
 
     validates :amount, presence: true, numericality: true
     validates :tax_category_id, presence: true


### PR DESCRIPTION
This branch adds missing dependent options to polymorphic associations to reduce instances of orphan records being created in the database.