### PR TITLE
Kill exception shadowing in API

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -18,7 +18,7 @@ module Spree
 
       after_filter  :set_jsonp_format
 
-      rescue_from Exception, with: :error_during_processing
+      rescue_from ActionController::ParameterMissing, with: :unprocessable_entity
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
       rescue_from CanCan::AccessDenied, with: :unauthorized
       rescue_from Spree::Core::GatewayError, with: :gateway_error
@@ -93,7 +93,7 @@ module Spree
         render "spree/api/errors/unauthorized", status: 401 and return
       end
 
-      def error_during_processing(exception)
+      def unprocessable_entity(exception)
         Rails.logger.error exception.message
         Rails.logger.error exception.backtrace.join("\n")
 

--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -2,6 +2,8 @@ module Spree
   module Api
     class UsersController < Spree::Api::BaseController
 
+      rescue_from Spree::Core::DestroyWithOrdersError, with: :unprocessable_entity
+
       def index
         @users = Spree.user_class.accessible_by(current_ability,:read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         respond_with(@users)

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -65,12 +65,12 @@ describe Spree::Api::BaseController, :type => :controller do
     end
   end
 
-  it 'handles exceptions' do
+  it 'handles parameter missing exceptions' do
     expect(subject).to receive(:authenticate_user).and_return(true)
     expect(subject).to receive(:load_user_roles).and_return(true)
-    expect(subject).to receive(:index).and_raise(Exception.new("no joy"))
-    get :index, :token => "fake_key"
-    expect(json_response).to eq({ "exception" => "no joy" })
+    expect(subject).to receive(:index).and_raise(ActionController::ParameterMissing.new('foo'))
+    get :index, token: 'exception-message'
+    expect(json_response).to eql('exception' => 'param is missing or the value is empty: foo')
   end
 
   it "maps semantic keys to nested_attributes keys" do

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -262,7 +262,9 @@ module Spree
     it "does not update line item needlessly" do
       expect(Order).to receive(:create!).and_return(order = Spree::Order.new)
       allow(order).to receive(:associate_user!)
-      allow(order).to receive_message_chain(:contents, :add).and_return(line_item = double('LineItem'))
+      line_item = double('LineItem')
+      allow(line_item).to receive_messages(save!: line_item)
+      allow(order).to receive_message_chain(:contents, :add).and_return(line_item)
       expect(line_item).not_to receive(:update_attributes)
       api_post :create, :order => {
         :line_items => {

--- a/api/spec/controllers/spree/api/states_controller_spec.rb
+++ b/api/spec/controllers/spree/api/states_controller_spec.rb
@@ -24,26 +24,29 @@ module Spree
     end
 
     context "pagination" do
+      let(:scope) { double('scope') }
+
       before do
-        expect(State).to receive(:accessible_by).and_return(@scope = double)
-        allow(@scope).to receive_message_chain(:ransack, :result, :includes, :order).and_return(@scope)
+        expect(scope).to receive_messages(last: state)
+        expect(State).to receive_messages(accessible_by: scope)
+        allow(scope).to receive_message_chain(:ransack, :result, :includes, :order).and_return(scope)
       end
 
       it "does not paginate states results when asked not to do so" do
-        expect(@scope).not_to receive(:page)
-        expect(@scope).not_to receive(:per)
+        expect(scope).not_to receive(:page)
+        expect(scope).not_to receive(:per)
         api_get :index
       end
 
       it "paginates when page parameter is passed through" do
-        expect(@scope).to receive(:page).with(1).and_return(@scope)
-        expect(@scope).to receive(:per).with(nil)
+        expect(scope).to receive(:page).with(1).and_return(scope)
+        expect(scope).to receive(:per).with(nil).and_return(scope)
         api_get :index, :page => 1
       end
 
       it "paginates when per_page parameter is passed through" do
-        expect(@scope).to receive(:page).with(nil).and_return(@scope)
-        expect(@scope).to receive(:per).with(25)
+        expect(scope).to receive(:page).with(nil).and_return(scope)
+        expect(scope).to receive(:per).with(25).and_return(scope)
         api_get :index, :per_page => 25
       end
     end
@@ -54,7 +57,7 @@ module Spree
 
       it "gets all states for a country" do
         country = create(:country, :states_required => true)
-        state.country = country 
+        state.country = country
         state.save
 
         api_get :index, :country_id => country.id


### PR DESCRIPTION
* Never rescue `Exception` without re-raising it.
* Mapping `Exception` to 422 is pure evil to API client developers
* Changes to rescue domain specific exceptions, while letting unexpected
  exceptions from *real* bugs pass through higher levels where *sane*
  developers/operators will have real monitoring available, just logging the
  error awayand mapping to 4xx range is not healthy
* Fixes all specs that had been silently failing because of unexpected
  exceptions and the mapping to 422 whithout any other kind of
  expectation signalling the failure to rspec.