### PR TITLE
Add missing factory params

### DIFF
--- a/api/spec/controllers/spree/api/inventory_units_controller_spec.rb
+++ b/api/spec/controllers/spree/api/inventory_units_controller_spec.rb
@@ -4,6 +4,8 @@ module Spree
   describe Api::InventoryUnitsController, :type => :controller do
     render_views
 
+    let(:other_variant) { create(:variant) }
+
     before do
       stub_authentication!
       @inventory_unit = create(:inventory_unit)
@@ -17,7 +19,7 @@ module Spree
         expect(json_response['state']).to eq @inventory_unit.state
       end
 
-      it "updates an inventory unit (only shipment is accessable by default)" do
+      it "updates an inventory unit (only shipment and variant_id are accessable)" do
         api_put :update, :id => @inventory_unit.id,
                          :inventory_unit => { :shipment => nil }
         expect(json_response['shipment_id']).to be_nil
@@ -27,20 +29,21 @@ module Spree
         it 'if supplied with :fire param' do
           api_put :update, :id => @inventory_unit.id,
                            :fire => 'ship',
-                           :inventory_unit => { :shipment => nil }
-
+                           :inventory_unit => { variant_id: other_variant.id }
           expect(json_response['state']).to eq 'shipped'
         end
 
         it 'and returns exception if cannot fire' do
           api_put :update, :id => @inventory_unit.id,
-                           :fire => 'return'
+                           :fire => 'return',
+                           :inventory_unit => { variant_id: other_variant.id }
           expect(json_response['exception']).to match /cannot transition to return/
         end
 
         it 'and returns exception bad state' do
           api_put :update, :id => @inventory_unit.id,
-                           :fire => 'bad'
+                           :fire => 'bad',
+                           :inventory_unit => { variant_id: other_variant.id }
           expect(json_response['exception']).to match /cannot transition to bad/
         end
       end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -32,6 +32,10 @@ module Spree
       end
     end
 
+    validates :state, :variant, :order, :shipment, :line_item, presence: true
+    validates :state,   inclusion: { in: %w[on_hand shipped backordered returned] }
+    validates :pending, inclusion: { in: [true, false] }
+
     # This was refactored from a simpler query because the previous implementation
     # lead to issues once users tried to modify the objects returned. That's due
     # to ActiveRecord `joins(shipment: :stock_location)` only return readonly
@@ -75,4 +79,3 @@ module Spree
       end
   end
 end
-

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -13,12 +13,12 @@ module Spree
             order = Spree::Order.create!
             order.associate_user!(user)
 
-            shipments_attrs = params.delete(:shipments_attributes)
-
-            create_shipments_from_params(shipments_attrs, order)
             create_line_items_from_params(params.delete(:line_items_attributes),order)
             create_adjustments_from_params(params.delete(:adjustments_attributes), order)
             create_payments_from_params(params.delete(:payments_attributes), order)
+
+            shipments_attrs = params.delete(:shipments_attributes)
+            create_shipments_from_params(shipments_attrs, order)
 
             if completed_at = params.delete(:completed_at)
               order.completed_at = completed_at

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -35,7 +35,8 @@ module Spree
             order.updater.update
             if shipments_attrs.present?
               order.shipments.each_with_index do |shipment, index|
-                shipment.update_columns(cost: shipments_attrs[index][:cost].to_f) if shipments_attrs[index][:cost].present?
+                cost = shipments_attrs[index][:cost].presence
+                shipment.update_columns(cost: cost.to_f) if cost
               end
             end
             order.reload

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -40,9 +40,9 @@ module Spree
               end
             end
             order.reload
-          rescue Exception => e
+          rescue Exception
             order.destroy if order && order.persisted?
-            raise e.message
+            raise
           end
         end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -17,7 +17,6 @@ module Spree
 
             create_shipments_from_params(shipments_attrs, order)
             create_line_items_from_params(params.delete(:line_items_attributes),order)
-            create_shipments_from_params(params.delete(:shipments_attributes), order)
             create_adjustments_from_params(params.delete(:adjustments_attributes), order)
             create_payments_from_params(params.delete(:payments_attributes), order)
 

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -1,9 +1,8 @@
 FactoryGirl.define do
   factory :inventory_unit, class: Spree::InventoryUnit do
-    variant
-    order
-    state 'on_hand'
+    order { create(:order_with_line_items, line_items_count: 1) }
+    line_item { order.line_items.first! }
+    variant { line_item.variant }
     association(:shipment, factory: :shipment, state: 'pending')
-    # return_authorization
   end
 end

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -12,8 +12,9 @@ FactoryGirl.define do
       shipment.order.line_items.each do |line_item|
         line_item.quantity.times do
           shipment.inventory_units.create(
-            variant_id: line_item.variant_id,
-            line_item_id: line_item.id
+            order:     line_item.order,
+            variant:   line_item.variant,
+            line_item: line_item
           )
         end
       end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -236,7 +236,8 @@ module Spree
 
       context "shipments" do
         let(:params) do
-          { :shipments_attributes => [
+          { :line_items_attributes => line_items,
+            :shipments_attributes => [
               { :tracking => '123456789',
                 :cost => '14.99',
                 :shipping_method => shipping_method.name,
@@ -248,6 +249,7 @@ module Spree
 
         it 'ensures variant exists and is not deleted' do
           expect(Importer::Order).to receive(:ensure_variant_id_from_params)
+            .twice.and_call_original
           order = Importer::Order.import(user,params)
         end
 
@@ -283,6 +285,7 @@ module Spree
           let(:params) do
             {
               :completed_at => 2.days.ago,
+              :line_items_attributes => line_items,
               :shipments_attributes => [
                 { :tracking => '123456789',
                   :cost => '4.99',

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -103,9 +103,7 @@ describe Spree::InventoryUnit, :type => :model do
   end
 
   context "variants deleted" do
-    let!(:unit) do
-      Spree::InventoryUnit.create(variant: stock_item.variant)
-    end
+    let!(:unit) { create(:inventory_unit) }
 
     it "can still fetch variant" do
       unit.variant.destroy

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -174,8 +174,8 @@ describe Spree::Shipment, :type => :model do
 
       context 'to_package' do
         let(:inventory_units) do
-          [build(:inventory_unit, line_item: line_item, variant: variant, state: 'on_hand'),
-           build(:inventory_unit, line_item: line_item, variant: variant, state: 'backordered')]
+          [build(:inventory_unit, state: 'on_hand'),
+           build(:inventory_unit, state: 'backordered')]
         end
 
         it 'should use symbols for states when adding contents to package' do


### PR DESCRIPTION
This branch supplies the available order object to the inventory unit object created in the factory.

[Related https://github.com/MountainRoseHerbs/mrh-spree/pull/1496]