### PR TITLE
Remove vendoring of gems from build-ci

### DIFF
--- a/build-ci.rb
+++ b/build-ci.rb
@@ -5,12 +5,9 @@ require 'pathname'
 class Project
   attr_reader :name
 
-  NODE_TOTAL = Integer(ENV.fetch('CIRCLE_NODE_TOTAL', 1))
-  NODE_INDEX = Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0))
-
-  ROOT          = Pathname.pwd.freeze
-  VENDOR_BUNDLE = ROOT.join('vendor', 'bundle').freeze
-
+  NODE_TOTAL      = Integer(ENV.fetch('CIRCLE_NODE_TOTAL', 1))
+  NODE_INDEX      = Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0))
+  ROOT            = Pathname.pwd.freeze
   BUNDLER_JOBS    = 4
   BUNDLER_RETRIES = 3
 
@@ -69,7 +66,6 @@ private
     system(%W[
       bundle
       install
-      --path #{VENDOR_BUNDLE}
       --jobs #{BUNDLER_JOBS}
       --retry #{BUNDLER_RETRIES}
     ])

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,8 @@ machine:
 dependencies:
   override:
     - ./build-ci.rb install
+  cache_directories:
+    - '~/.rvm/gems/ruby-2.2.3/gems/'
 test:
   override:
     - './build-ci.rb test':


### PR DESCRIPTION
* This was needed when we wanted to exploit the fact the root Gemfile
  was present and installing into `/vendor` on CI.
* Now we can just use the default, that will also help on local
  executions because this will exploit the users gem directory as
  cache.