### PR TITLE
Remove spree version

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -1,6 +1,5 @@
 require "rails/generators/rails/app/app_generator"
 require 'active_support/core_ext/hash'
-require 'spree/core/version'
 
 module Spree
   class DummyGenerator < Rails::Generators::Base

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -34,14 +34,6 @@ module Spree
       template 'config/initializers/spree.rb', 'config/initializers/spree.rb'
     end
 
-    def config_spree_yml
-      create_file "config/spree.yml" do
-        settings = { 'version' => Spree.version }
-
-        settings.to_yaml
-      end
-    end
-
     def additional_tweaks
       return unless File.exists? 'public/robots.txt'
       append_file "public/robots.txt", <<-ROBOTS

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -50,8 +50,6 @@ module Spree
   end
 end
 
-require 'spree/core/version'
-
 require 'spree/core/environment_extension'
 require 'spree/core/environment/calculators'
 require 'spree/core/environment'

--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -1,5 +1,0 @@
-module Spree
-  def self.version
-    '2.4.11.beta'
-  end
-end


### PR DESCRIPTION
* It has no specs
* Its redundant with the gem version
* Nobody should program against the spree version
* On need to learn the active spree version use `bundle show spree_core`
  this is far more up-to-date than a likely to go stale
  `config/spree.yml`.