### PR TITLE
Fix isolation of factory validation

### DIFF
--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -39,18 +39,7 @@ RSpec.configure do |config|
 
   # Test the factories
   config.before(:suite) do
-    DatabaseCleaner.cleaning do
-      factories = FactoryGirl.factories.reject do |factory|
-        %i[
-          customer_return_without_return_items
-          global_zone
-          stock_packer
-          stock_package
-          stock_package_fulfilled
-        ].include?(factory.name)
-      end
-      FactoryGirl.lint(factories)
-    end
+    FactoryValidation.call
   end
 
   # Wrap all db isolated tests in a transaction

--- a/core/spec/support/factory_validation.rb
+++ b/core/spec/support/factory_validation.rb
@@ -1,0 +1,53 @@
+require 'ice_nine'
+
+# @api private
+module FactoryValidation
+  EXCLUDED_FACTORIES = IceNine.deep_freeze(%i[
+    customer_return_without_return_items
+    stock_packer
+    stock_package
+    stock_package_fulfilled
+  ].to_set)
+
+  TRANSACTION_OPTIONS = IceNine.deep_freeze(isolation: :serializable)
+
+  private_constant(*constants(false))
+
+  # Validate factories
+  #
+  # @return [self]
+  #
+  # @raise [Exception]
+  #   on failed validation
+  #
+  def self.call
+    (factory_names - EXCLUDED_FACTORIES).each(&method(:lint))
+
+    self
+  end
+
+  # The factory names
+  #
+  # @return [Set<Symbol>]
+  def self.factory_names
+    FactoryGirl.factories.map(&:name).to_set
+  end
+  private_class_method :factory_names
+
+  # Perform validation of factory
+  #
+  # @param factory_name [Symbol]
+  #
+  # @return [undefined]
+  #
+  # @raise [Exception]
+  #   on failed validation
+  #
+  def self.lint(factory_name)
+    ActiveRecord::Base.transaction(TRANSACTION_OPTIONS) do |transaction|
+      FactoryGirl.create(factory_name)
+      fail ActiveRecord::Rollback
+    end
+  end
+  private_class_method :lint
+end # FactoryValidation


### PR DESCRIPTION
Fixes the factory validation to be performed isolated from each other.

The specs are isolated also, when validating the factories we should assume the same.

DB side constraints that are deferred will be skipped from validation with that implementation approach. The current schema does not contain those constraints, so the approach is valid.

As an unintended side effect the time spend on valdiating factories reduced to 8s from 22s.

Also it makes the full stack trace visible. And fails on first error. This is far more healthy for debugging.