### PR TITLE
Remove redundant rspec metadata

### DIFF
--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'email_spec'
 
-describe Spree::OrderMailer, type: :mailer, db: :isolate do
+describe Spree::OrderMailer, type: :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'spree/testing_support/order_walkthrough'
 
-describe Spree::Order, type: :model, db: :isolate do
+describe Spree::Order, type: :model do
   let!(:store) { create(:store, default: true) }
   let(:order)  { store.orders.new              }
 

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Order, type: :model, db: :isolate do
+describe Spree::Order, type: :model do
   context "#finalize!" do
     let(:order) { create(:order, email: 'test@example.com') }
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -6,7 +6,7 @@ class FakeCalculator < Spree::Calculator
   end
 end
 
-describe Spree::Order, type: :model, db: :isolate do
+describe Spree::Order, type: :model do
   let(:user)  { stub_model(Spree::LegacyUser, email: "spree@example.com") }
   let(:order) { stub_model(Spree::Order, user: user)                      }
 

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Store, type: :model, db: :isolate do
+describe Spree::Store, type: :model do
 
   describe '.by_url' do
     let!(:store)    { create(:store, url: "website1.com\nwww.subdomain.com") }


### PR DESCRIPTION
* DB isolation is now applied globally uncoditionally as all implict
  data dependencies where fixed meanwhile.

Exctration from #127 