### PR TITLE
Remove specs for multiple incomplete orders per user

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -84,26 +84,6 @@ module Spree
         expect(response.status).to eq(200)
         expect(json_response["orders"].length).to eq(0)
       end
-
-      it "returns orders in reverse chronological order by completed_at" do
-        order.update_columns completed_at: Time.now
-
-        order2 = store.orders.create!(user: order.user, completed_at: Time.now - 1.day)
-        expect(order2.created_at).to be > order.created_at
-        order3 = store.orders.create!(user: order.user)
-        expect(order3.created_at).to be > order2.created_at
-        order4 = store.orders.create!(user: order.user)
-        expect(order4.created_at).to be > order3.created_at
-
-        api_get :mine
-        expect(response.status).to eq(200)
-        expect(json_response["pages"]).to eq(1)
-        expect(json_response["orders"].length).to eq(4)
-        expect(json_response["orders"][0]["number"]).to eq(order.number)
-        expect(json_response["orders"][1]["number"]).to eq(order2.number)
-        expect(json_response["orders"][2]["number"]).to eq(order4.number)
-        expect(json_response["orders"][3]["number"]).to eq(order3.number)
-      end
     end
 
     describe 'current' do
@@ -120,16 +100,7 @@ module Spree
         end
       end
 
-      context "multiple incomplete orders exist" do
-        it "returns the latest incomplete order" do
-          new_order = create(:order, store: store, user: order.user)
-          expect(new_order.created_at).to be > order.created_at
-          expect(JSON.parse(subject.body)['id']).to eq new_order.id
-        end
-      end
-
       context "an incomplete order does not exist" do
-
         before do
           order.update_attribute(:state, order_state)
           order.update_attribute(:completed_at, 5.minutes.ago)


### PR DESCRIPTION
* These cannot happen anymore as we fixed order merging to always
  collapse the guest orders into the last incomplete order as soon a
  guest order can be associtated with a user.