### PR TITLE
Remove unhelpful custom #inspect

### DIFF
--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -69,12 +69,6 @@ module Spree
         shipping_categories.map(&:shipping_methods).reduce(:&).to_a
       end
 
-      def inspect
-        contents.map do |content_item|
-          "#{content_item.variant.name} #{content_item.state}"
-        end.join(' / ')
-      end
-
       def to_shipment
         # At this point we should only have one content item per inventory unit
         # across the entire set of inventory units to be shipped, which has been

--- a/core/config/flay.yml
+++ b/core/config/flay.yml
@@ -1,4 +1,4 @@
 ---
 threshold: 77
-total_score: 4577
+total_score: 4572
 lib_dirs: ['app', 'lib']


### PR DESCRIPTION
* A custom inspect only makes sense when it contains all relevant state
* This one was in my way when debugging multiple times, so killing it.