### PR TITLE
Improve variants having order

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -43,13 +43,6 @@ module Spree
 
     scope :in_stock, -> { joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false) }
 
-    self.whitelisted_ransackable_associations = %w[option_values product prices default_price]
-    self.whitelisted_ransackable_attributes = %w[weight sku]
-
-    def self.active(currency = nil)
-      joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
-    end
-
     # rubocop:disable Lambda
     scope :having_orders, -> do
       line_items_table_name = reflect_on_association(:line_items).quoted_table_name
@@ -64,6 +57,13 @@ module Spree
             #{line_items_table_name}.variant_id = #{quoted_table_name}.id
         )
       SQL
+    end
+
+    self.whitelisted_ransackable_associations = %w[option_values product prices default_price]
+    self.whitelisted_ransackable_attributes = %w[weight sku]
+
+    def self.active(currency = nil)
+      joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end
 
     def tax_category

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -50,8 +50,20 @@ module Spree
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end
 
-    def self.having_orders
-      joins(:line_items).distinct
+    # rubocop:disable Lambda
+    scope :having_orders, -> do
+      line_items_table_name = reflect_on_association(:line_items).quoted_table_name
+
+      where(<<-SQL.squish)
+        EXISTS (
+          SELECT
+            *
+          FROM
+            #{line_items_table_name}
+          WHERE
+            #{line_items_table_name}.variant_id = #{quoted_table_name}.id
+        )
+      SQL
     end
 
     def tax_category

--- a/core/config/flay.yml
+++ b/core/config/flay.yml
@@ -1,4 +1,4 @@
 ---
 threshold: 77
-total_score: 4572
+total_score: 4588
 lib_dirs: ['app', 'lib']


### PR DESCRIPTION
Dramatically improves the performance of `Variant#having_orders`, on a big installation with millions of orders.

Before:

```
  (3135.4ms)  SELECT DISTINCT "spree_variants"."sku", "spree_variants"."id" FROM "spree_variants" INNER JOIN "spree_line_items" ON "spree_line_items"."variant_id" = "spree_variants"."id" WHERE "spree_variants"."deleted_at" IS NULL  ORDER BY "spree_variants"."sku" ASC
```

After:

```
(70.6ms)  SELECT "spree_variants"."sku", "spree_variants"."id" FROM "spree_variants"  WHERE "spree_variants"."deleted_at" IS NULL AND (EXISTS (SELECT * FROM spree_line_items WHERE spree_line_items.variant_id = spree_variants.id))  ORDER BY "spree_variants"."sku" ASC
```

As we have uniqueness constraints on the `sku` both queries are equivalent.